### PR TITLE
Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# curl2http
+
+A simple CLI tool written in Go to convert curl commands into human-readable HTTP requests for easier debugging and testing.
+
+## Installation
+
+```shell
+go install github.com/dchf12/curl2http@latest
+```
+
+## Usage
+
+### From Pipe or Standard Input
+
+```shell
+echo 'curl -X POST https://example.com --json "{\"A\":\"B\"}"' | curl2http
+```
+
+**Output:**
+```
+POST https://example.com
+content: application/json
+
+{
+  "A": "B"
+}
+```
+
+### From File
+
+```shell
+curl2http < request.txt
+```
+
+## Error Handling
+
+In case of an invalid curl command, a brief error code will be printed to standard error.
+
+## Testing
+
+Developed using Test-Driven Development (TDD). Aim for a coverage of ~70%.
+
+```shell
+go test ./...
+```
+
+## License
+
+MIT
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ echo 'curl -X POST https://example.com --json "{\"A\":\"B\"}"' | curl2http
 **Output:**
 ```
 POST https://example.com
-content: application/json
+content-type: application/json
 
 {
   "A": "B"

--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+func Format(req *Request) string {
+	var output strings.Builder
+
+	output.WriteString(req.Method)
+	output.WriteString(" ")
+	output.WriteString(req.URL)
+	output.WriteString("\n")
+
+	var keys []string
+	for k := range req.Headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		output.WriteString(k)
+		output.WriteString(": ")
+		output.WriteString(req.Headers[k])
+		output.WriteString("\n")
+	}
+
+	if req.ContentType != "" && len(req.Headers) == 0 {
+		output.WriteString("content-type: ")
+		output.WriteString(req.ContentType)
+		output.WriteString("\n")
+	}
+
+	if req.Body == "" {
+		return output.String()
+	}
+	output.WriteString("\n")
+
+	if req.ContentType == "application/json" {
+		var jsonObj any
+		if err := json.Unmarshal([]byte(req.Body), &jsonObj); err == nil {
+			if formatted, err := json.MarshalIndent(jsonObj, "", "  "); err == nil {
+				output.Write(formatted)
+				output.WriteString("\n")
+				return output.String()
+			}
+		}
+	}
+
+	output.WriteString(req.Body)
+	output.WriteString("\n")
+	return output.String()
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func Test_Format(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *Request
+		want    string
+	}{
+		{
+			name: "基本的なGETリクエスト",
+			request: &Request{
+				Method:      "GET",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "",
+				Body:        "",
+			},
+			want: "GET https://example.com\n",
+		},
+		{
+			name: "POSTリクエスト（JSONボディ）",
+			request: &Request{
+				Method:      "POST",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "application/json",
+				Body:        `{"A":"B"}`,
+			},
+			want: "POST https://example.com\ncontent-type: application/json\n\n{\n  \"A\": \"B\"\n}\n",
+		},
+		{
+			name: "ヘッダーありのリクエスト",
+			request: &Request{
+				Method:  "GET",
+				URL:     "https://example.com",
+				Headers: map[string]string{"Authorization": "Bearer token", "Content-Type": "application/json"},
+				Body:    "",
+			},
+			want: "GET https://example.com\nAuthorization: Bearer token\nContent-Type: application/json\n",
+		},
+		{
+			name: "無効なJSONボディ",
+			request: &Request{
+				Method:      "POST",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "application/json",
+				Body:        `{"A":"B"`,
+			},
+			want: "POST https://example.com\ncontent-type: application/json\n\n{\"A\":\"B\"\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Format(tt.request); got != tt.want {
+				t.Errorf("Format() got =%v\nwant =%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func run(r io.Reader, w io.Writer) error {
+	input, err := readInput(r)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return fmt.Errorf("input is empty")
+	}
+
+	if !strings.HasPrefix(input, "curl") {
+		return fmt.Errorf("input is not curl command")
+	}
+
+	request, err := Parse(input)
+	if err != nil {
+		return fmt.Errorf("failed to parse curl command: %w", err)
+	}
+
+	_, err = fmt.Fprint(w, Format(request))
+	return err
+}
+
+func readInput(r io.Reader) (string, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func Test_ReadInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "シンプルな入力",
+			input:   "curl https://example.com",
+			want:    "curl https://example.com",
+			wantErr: false,
+		},
+		{
+			name: "複数行の入力",
+			input: `curl -X POST https://example.com \
+--json '{"A":"B"}'`,
+			want: `curl -X POST https://example.com \
+--json '{"A":"B"}'`,
+			wantErr: false,
+		},
+		{
+			name:    "空の入力",
+			input:   "",
+			want:    "",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.input)
+			got, err := readInput(reader)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readInput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("readInput() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_Run(t *testing.T) {
+	reader := strings.NewReader("curl -X POST https://example.com --json '{\"A\":\"B\"}'")
+	var writer bytes.Buffer
+
+	err := run(reader, &writer)
+	if err != nil {
+		t.Errorf("run() error = %v", err)
+	}
+
+	expected := "POST https://example.com\ncontent-type: application/json\n\n{\n  \"A\": \"B\"\n}\n"
+	if writer.String() != expected {
+		t.Errorf("run() got = %v, want %v", writer.String(), expected)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -46,7 +46,11 @@ func Parse(curlCmd string) (*Request, error) {
 	jsonMatches := jsonPattern.FindStringSubmatch(curlCmd)
 	if len(jsonMatches) >= 3 {
 		req.ContentType = "application/json"
-		req.Body = jsonMatches[2]
+		if jsonMatches[1] != "" {
+			req.Body = jsonMatches[1]
+		} else {
+			req.Body = jsonMatches[2]
+		}
 	}
 
 	// bodyを取得

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// Request 解析されたリクエスト情報
+type Request struct {
+	Method      string
+	URL         string
+	Headers     map[string]string
+	ContentType string
+	Body        string
+}
+
+// Parse curlコマンドを解析してRequest構造体を返す
+func Parse(curlCmd string) (*Request, error) {
+	curlCmd = strings.TrimSpace(curlCmd)
+
+	// default request
+	req := &Request{
+		Method:  "GET",
+		Headers: map[string]string{},
+	}
+
+	// 複数行のcurlコマンドを1行にする
+	curlCmd = cleanCurlCmd(curlCmd)
+
+	// URLを取得
+	urlPattern := regexp.MustCompile(`curl\s+(?:-X\s+\w+\s+)?(['"]?)(https?://[^\s'"]+)(['"]?)`)
+	urlMatches := urlPattern.FindStringSubmatch(curlCmd)
+	if len(urlMatches) >= 3 {
+		req.URL = urlMatches[2]
+	}
+	// メソッドを取得
+	methodPattern := regexp.MustCompile(`-X\s+(\w+)`)
+	methodMatches := methodPattern.FindStringSubmatch(curlCmd)
+	if len(methodMatches) >= 2 {
+		req.Method = methodMatches[1]
+	}
+
+	// JSONボディを取得
+	jsonPattern := regexp.MustCompile(`--json\s+(?:"([^"]+)"|'([^']+)')`)
+	jsonMatches := jsonPattern.FindStringSubmatch(curlCmd)
+	if len(jsonMatches) >= 3 {
+		req.ContentType = "application/json"
+		req.Body = jsonMatches[2]
+	}
+
+	// bodyを取得
+	dataPattern := regexp.MustCompile(`-d\s+(['"])(.*?)(['"])|--data\s+(['"])(.*?)(['"])`)
+	dataMatches := dataPattern.FindStringSubmatch(curlCmd)
+	if len(dataMatches) >= 3 && req.Body == "" {
+		if req.ContentType == "" {
+			req.ContentType = "application/x-www-form-urlencoded"
+		}
+		if dataMatches[2] != "" {
+			req.Body = dataMatches[2]
+		} else if len(dataMatches) >= 6 {
+			req.Body = dataMatches[5]
+		}
+	}
+
+	// headerを取得
+	headerPattern := regexp.MustCompile(`-H\s+(['"])(.*?)(['"])`)
+	headerMatches := headerPattern.FindAllStringSubmatch(curlCmd, -1)
+	for _, match := range headerMatches {
+		if len(match) >= 3 {
+			headerLine := match[2]
+			parts := strings.SplitN(headerLine, ":", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+				req.Headers[key] = value
+
+				// Content-Typeヘッダーがある場合は更新
+				if strings.ToLower(key) == "content-type" {
+					req.ContentType = value
+				}
+			}
+		}
+	}
+
+	if req.URL == "" {
+		return nil, errors.New("URLが見つかりません")
+	}
+	return req, nil
+}
+
+// cleanCurlCmd 複数行のcurlコマンドを1行にする
+func cleanCurlCmd(cmd string) string {
+	cmd = strings.ReplaceAll(cmd, "\\\n", " ")
+	cmd = regexp.MustCompile(`\s+`).ReplaceAllString(cmd, " ")
+	return cmd
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_Parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		curlCmd string
+		want    *Request
+		wantErr bool
+	}{
+		{
+			name:    "基本的なGETリクエスト",
+			curlCmd: "curl https://example.com",
+			want: &Request{
+				Method:      "GET",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "",
+				Body:        "",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "メソッド指定あり",
+			curlCmd: "curl -X POST https://example.com",
+			want: &Request{
+				Method:      "POST",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "",
+				Body:        "",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "JSONボディあり",
+			curlCmd: `curl -X POST https://example.com --json '{"A":"B"}'`,
+			want: &Request{
+				Method:      "POST",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "application/json",
+				Body:        `{"A":"B"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "複数行のコマンド",
+			curlCmd: `curl -X POST https://example.com \
+  --json '{"A":"B"}'`,
+			want: &Request{
+				Method:      "POST",
+				URL:         "https://example.com",
+				Headers:     map[string]string{},
+				ContentType: "application/json",
+				Body:        `{"A":"B"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "ヘッダーあり",
+			curlCmd: `curl -X GET https://example.com -H "Authorization: Bearer token"`,
+			want: &Request{
+				Method:      "GET",
+				URL:         "https://example.com",
+				Headers:     map[string]string{"Authorization": "Bearer token"},
+				ContentType: "",
+				Body:        "",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "不正なコマンド",
+			curlCmd: "invalid command",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.curlCmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_CleanCurlCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "1行",
+			cmd:  "curl https://example.com",
+			want: "curl https://example.com",
+		},
+		{
+			name: "複数行",
+			cmd: `curl -X POST \
+					https://example.com \
+					-H "Content-Type: application/json" \
+					-json '{"key": "value"}'`,
+			want: "curl -X POST https://example.com -H \"Content-Type: application/json\" -json '{\"key\": \"value\"}'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanCurlCmd(tt.cmd)
+			if got != tt.want {
+				t.Errorf("cleanCurlCmd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- https://github.com/dchf12/ToDo-issues/issues/198
```
プルリクエストの説明
このプルリクエストでは、以下の変更が行われました：

README.mdの追加:

プロジェクトの概要、インストール方法、使用方法、エラーハンドリング、テスト方法、ライセンスについて記載しています。
formatter.goの追加:

curlコマンドをパースし、整形されたHTTPリクエストとして出力する関数Formatを実装しました。
formatter_test.goの追加:

Format関数のテストケースを追加し、GETリクエスト、POSTリクエスト、ヘッダー付きリクエスト、無効なJSONボディのテストを行いました。
main.goの追加:

標準入力からのcurlコマンドを読み取り、整形されたHTTPリクエストとして標準出力に出力するメインプログラムを実装しました。
main_test.goの追加:

標準入力からの読み取りおよびメインプログラムのテストケースを追加しました。
parser.goの追加:

curlコマンドを解析し、HTTPリクエスト情報を表す構造体Requestを返す関数Parseを実装しました。
parser_test.goの追加:

Parse関数のテストケースを追加し、基本的なGETリクエスト、メソッド指定ありのリクエスト、JSONボディ付きのPOSTリクエスト、複数行のコマンド、ヘッダー付きリクエスト、不正なコマンドのテストを行いました。
これらの変更により、curlコマンドを簡単に人間が読みやすいHTTPリクエスト形式に変換できるようになりました。
```